### PR TITLE
FEATURE: Ladder Filter

### DIFF
--- a/src/PhantomEditor.cpp
+++ b/src/PhantomEditor.cpp
@@ -127,6 +127,16 @@ PhantomAudioProcessorEditor::PhantomAudioProcessorEditor(PhantomAudioProcessor& 
     m_filterResoLabel.attachToComponent(&m_filterResoSlider, false);
     addAndMakeVisible(&m_filterResoLabel);
 
+    m_filterDriveSlider.setSliderStyle(Slider::RotaryHorizontalVerticalDrag);
+    m_filterDriveSlider.setTextBoxStyle(Slider::TextBoxBelow, false, textBoxWidth, textBoxHeight);
+    m_filterDriveSlider.setDoubleClickReturnValue(true, Consts::_FLTR_DRIVE_DEFAULT_VAL);
+    m_filterDriveSliderAttachment.reset(new SliderAttachment(m_parameters, Consts::_FLTR_DRIVE_PARAM_ID, m_filterDriveSlider));
+    addAndMakeVisible(&m_filterDriveSlider);
+    m_filterDriveLabel.setText("Drive", dontSendNotification);
+    m_filterDriveLabel.setJustificationType(Justification::centred);
+    m_filterDriveLabel.attachToComponent(&m_filterDriveSlider, false);
+    addAndMakeVisible(&m_filterDriveLabel);
+
     m_filterEgModDepthSlider.setSliderStyle(Slider::RotaryHorizontalVerticalDrag);
     m_filterEgModDepthSlider.setTextBoxStyle(Slider::TextBoxBelow, false, textBoxWidth, textBoxHeight);
     m_filterEgModDepthSlider.setDoubleClickReturnValue(true, Consts::_FLTR_EG_MOD_DEPTH_DEFAULT_VAL);
@@ -386,6 +396,7 @@ PhantomAudioProcessorEditor::~PhantomAudioProcessorEditor()
 
     m_filterCutoffSliderAttachment = nullptr;
     m_filterResoSliderAttachment = nullptr;
+    m_filterDriveSliderAttachment = nullptr;
     m_filterEgModDepthSliderAttachment = nullptr;
     m_filterLfoModDepthSliderAttachment = nullptr;
 
@@ -475,6 +486,7 @@ void PhantomAudioProcessorEditor::resized()
     Rectangle<int> filterAreaTop = filterArea.removeFromTop(filterArea.getHeight() / 2);
     m_filterCutoffSlider.setBounds(filterAreaTop.removeFromLeft(knobWidth));
     m_filterResoSlider.setBounds(filterAreaTop.removeFromLeft(knobWidth));
+    m_filterDriveSlider.setBounds(filterAreaTop);
     m_filterEgModDepthSlider.setBounds(filterArea.removeFromLeft(knobWidth * 1.5));
     m_filterLfoModDepthSlider.setBounds(filterArea);
     

--- a/src/PhantomEditor.h
+++ b/src/PhantomEditor.h
@@ -70,6 +70,9 @@ private:
     Slider m_filterResoSlider;
     Label m_filterResoLabel;
     std::unique_ptr<SliderAttachment> m_filterResoSliderAttachment;
+    Slider m_filterDriveSlider;
+    Label m_filterDriveLabel;
+    std::unique_ptr<SliderAttachment> m_filterDriveSliderAttachment;
     Slider m_filterEgModDepthSlider;
     Label m_filterEgModDepthLabel;
     std::unique_ptr<SliderAttachment> m_filterEgModDepthSliderAttachment;

--- a/src/PhantomFilter.cpp
+++ b/src/PhantomFilter.cpp
@@ -16,13 +16,13 @@
 PhantomFilter::PhantomFilter(AudioProcessorValueTreeState& vts, dsp::ProcessSpec& ps)
     :   m_parameters(vts)
 {
-    m_filter = new dsp::StateVariableTPTFilter<float>();
+    m_filter = new dsp::LadderFilter<float>();
     m_filter->prepare(ps);
-    m_filter->setType(m_type);
-    m_filter->snapToZero();
+    m_filter->setEnabled(true);
 
     p_cutoff = m_parameters.getRawParameterValue(Consts::_FLTR_CUTOFF_PARAM_ID);
     p_resonance = m_parameters.getRawParameterValue(Consts::_FLTR_RESO_PARAM_ID);
+    p_drive = m_parameters.getRawParameterValue(Consts::_FLTR_DRIVE_PARAM_ID);
     p_egModDepth = m_parameters.getRawParameterValue(Consts::_FLTR_EG_MOD_DEPTH_PARAM_ID);
     p_lfoModDepth = m_parameters.getRawParameterValue(Consts::_FLTR_LFO_MOD_DEPTH_PARAM_ID);
 
@@ -35,6 +35,7 @@ PhantomFilter::~PhantomFilter()
 
     p_cutoff = nullptr;
     p_resonance = nullptr;
+    p_drive = nullptr;
     p_egModDepth = nullptr;
     p_lfoModDepth = nullptr;
 }
@@ -44,27 +45,23 @@ void PhantomFilter::update() noexcept
 {
     // NOTE: Frequency is not being set here because it is called in the update 
     // function. Discontinuous numbers could result in artifacts.
+
     m_filter->setResonance(*p_resonance);
+    m_filter->setDrive(*p_drive);
 }
 
 //==============================================================================
 float PhantomFilter::evaluate(float sample, float egMod, float lfoMod) noexcept
 {
-    // egMod = egMod * 2.0f - 1.0f;
-    // egMod *= *p_egModDepth;
-    // lfoMod *= *p_lfoModDepth;
-    // float mod = (egMod + lfoMod) * 0.5f + 0.5f;
-    // float offset = k_cutoffModulationMultiplier * mod;
-
     float envelope = *p_egModDepth * egMod * (abs(*p_lfoModDepth) * -0.5f + 1.0f);
     float lfo = *p_lfoModDepth * (lfoMod * 0.5f + 0.5f) * (abs(*p_egModDepth) * -0.5f + 1.0f);
     float mod = envelope + lfo;
     float offset = k_cutoffModulationMultiplier * mod;
 
     float frequency = clip(*p_cutoff + offset, k_cutoffLowerBounds, k_cutoffUpperCounds);
-    m_filter->setCutoffFrequency(frequency);
+    m_filter->setCutoffFrequencyHz(frequency);
 
-    return m_filter->processSample(k_channelNumber, sample);
+    return m_filter->processSample(sample, k_channelNumber);
 }
 
 float PhantomFilter::clip(float n, float lower, float upper) noexcept

--- a/src/PhantomFilter.h
+++ b/src/PhantomFilter.h
@@ -40,6 +40,7 @@ private:
 
     std::atomic<float>* p_cutoff;
     std::atomic<float>* p_resonance;
+    std::atomic<float>* p_drive;
     std::atomic<float>* p_egModDepth;
     std::atomic<float>* p_lfoModDepth;
 
@@ -49,6 +50,5 @@ private:
     const float k_cutoffUpperCounds = 11000.0f;
 
     //==========================================================================
-    dsp::StateVariableTPTFilter<float>* m_filter;
-    dsp::StateVariableTPTFilterType m_type = dsp::StateVariableTPTFilterType::lowpass;
+    dsp::LadderFilter<float>* m_filter;
 };

--- a/src/PhantomProcessor.cpp
+++ b/src/PhantomProcessor.cpp
@@ -250,6 +250,13 @@ AudioProcessorValueTreeState::ParameterLayout PhantomAudioProcessor::createParam
     );
     params.push_back(std::move(filterReso));
 
+    auto filterDrive = std::make_unique<AudioParameterFloat>(
+        Consts::_FLTR_DRIVE_PARAM_ID, Consts::_FLTR_DRIVE_PARAM_NAME,
+        NormalisableRange<float>(1.0f, 10.0f, 0.1f),
+        Consts::_FLTR_DRIVE_DEFAULT_VAL
+    );
+    params.push_back(std::move(filterDrive));
+
     auto filterEgModDepth = std::make_unique<AudioParameterFloat>(
         Consts::_FLTR_EG_MOD_DEPTH_PARAM_ID, Consts::_FLTR_EG_MOD_DEPTH_PARAM_NAME,
         NormalisableRange<float>(-1.0f, 1.0f, 0.01f),

--- a/src/PhantomUtils.h
+++ b/src/PhantomUtils.h
@@ -109,6 +109,9 @@ namespace Consts {
     constexpr char* _FLTR_RESO_PARAM_ID = "filterReso";
     constexpr char* _FLTR_RESO_PARAM_NAME = "Filter Resonance";
     constexpr float _FLTR_RESO_DEFAULT_VAL = 0.70710678;
+    constexpr char* _FLTR_DRIVE_PARAM_ID = "filterDrive";
+    constexpr char* _FLTR_DRIVE_PARAM_NAME = "Filter Drive";
+    constexpr float _FLTR_DRIVE_DEFAULT_VAL = 1.0f;
     constexpr char* _FLTR_EG_MOD_DEPTH_PARAM_ID = "filterEgModDepth";
     constexpr char* _FLTR_EG_MOD_DEPTH_PARAM_NAME = "Filter EG Mod Depth";
     constexpr float _FLTR_EG_MOD_DEPTH_DEFAULT_VAL = 0.0f;


### PR DESCRIPTION
## Type

- [ ] _chore_ - simple, grunt tasks like updating a library
- [x] _feature_ - implementation of a new functionality, behavior, design, etc.
- [ ] _fix_ - fixing bugs or other things
- [ ] _refactor_ - improving existing code without changing external behavior
- [ ] _sandbox_ - prototyping, designing, or testing new things
- [ ] _test_ - things related to tests

## Summary

JUCE's ladder filter will be a really awesome-sounding component to put in this synth mainly because it's got a drive parameter to help distort it a bit giving it a nice flavor. If this filter becomes too intense for the CPU then that is just the name of the game (might try again later down the road when the synth is more solidified in its feature set.

*NOTE: The planned implementation for this card will **NOT** contain parameters to control the slope or mode (HP, LP, BP, etc.). This will be added later in a more finalized GUI state since these (IMO) aren't the most important filter parameters to worry about.*

[Trello Card](https://trello.com/c/pYDFgiTF/30-02-01-2021-feature-filter-drive)

## Notes

- For this implementation to work, it's required to make the LadderFilter's `processSample()` method public rather than protected (which also means that CI tests **WILL** fail)
- CPU usage spikes are crazy (in Ableton), so this PR is still a WIP