### PR TITLE
FEATURE: Filter Drive

### DIFF
--- a/src/PhantomEditor.cpp
+++ b/src/PhantomEditor.cpp
@@ -127,6 +127,16 @@ PhantomAudioProcessorEditor::PhantomAudioProcessorEditor(PhantomAudioProcessor& 
     m_filterResoLabel.attachToComponent(&m_filterResoSlider, false);
     addAndMakeVisible(&m_filterResoLabel);
 
+    m_filterDriveSlider.setSliderStyle(Slider::RotaryHorizontalVerticalDrag);
+    m_filterDriveSlider.setTextBoxStyle(Slider::TextBoxBelow, false, textBoxWidth, textBoxHeight);
+    m_filterDriveSlider.setDoubleClickReturnValue(true, Consts::_FLTR_DRIVE_DEFAULT_VAL);
+    m_filterDriveSliderAttachment.reset(new SliderAttachment(m_parameters, Consts::_FLTR_DRIVE_PARAM_ID, m_filterDriveSlider));
+    addAndMakeVisible(&m_filterDriveSlider);
+    m_filterDriveLabel.setText("Drive", dontSendNotification);
+    m_filterDriveLabel.setJustificationType(Justification::centred);
+    m_filterDriveLabel.attachToComponent(&m_filterDriveSlider, false);
+    addAndMakeVisible(&m_filterDriveLabel);
+
     m_filterEgModDepthSlider.setSliderStyle(Slider::RotaryHorizontalVerticalDrag);
     m_filterEgModDepthSlider.setTextBoxStyle(Slider::TextBoxBelow, false, textBoxWidth, textBoxHeight);
     m_filterEgModDepthSlider.setDoubleClickReturnValue(true, Consts::_FLTR_EG_MOD_DEPTH_DEFAULT_VAL);
@@ -386,6 +396,7 @@ PhantomAudioProcessorEditor::~PhantomAudioProcessorEditor()
 
     m_filterCutoffSliderAttachment = nullptr;
     m_filterResoSliderAttachment = nullptr;
+    m_filterDriveSliderAttachment = nullptr;
     m_filterEgModDepthSliderAttachment = nullptr;
     m_filterLfoModDepthSliderAttachment = nullptr;
 
@@ -475,6 +486,7 @@ void PhantomAudioProcessorEditor::resized()
     Rectangle<int> filterAreaTop = filterArea.removeFromTop(filterArea.getHeight() / 2);
     m_filterCutoffSlider.setBounds(filterAreaTop.removeFromLeft(knobWidth));
     m_filterResoSlider.setBounds(filterAreaTop.removeFromLeft(knobWidth));
+    m_filterDriveSlider.setBounds(filterAreaTop);
     m_filterEgModDepthSlider.setBounds(filterArea.removeFromLeft(knobWidth * 1.5));
     m_filterLfoModDepthSlider.setBounds(filterArea);
     

--- a/src/PhantomEditor.h
+++ b/src/PhantomEditor.h
@@ -70,6 +70,9 @@ private:
     Slider m_filterResoSlider;
     Label m_filterResoLabel;
     std::unique_ptr<SliderAttachment> m_filterResoSliderAttachment;
+    Slider m_filterDriveSlider;
+    Label m_filterDriveLabel;
+    std::unique_ptr<SliderAttachment> m_filterDriveSliderAttachment;
     Slider m_filterEgModDepthSlider;
     Label m_filterEgModDepthLabel;
     std::unique_ptr<SliderAttachment> m_filterEgModDepthSliderAttachment;

--- a/src/PhantomFilter.cpp
+++ b/src/PhantomFilter.cpp
@@ -16,9 +16,10 @@
 PhantomFilter::PhantomFilter(AudioProcessorValueTreeState& vts, dsp::ProcessSpec& ps)
     :   m_parameters(vts)
 {
-    m_filter = new dsp::LadderFilter<float>();
+    m_filter = new dsp::StateVariableTPTFilter<float>();
     m_filter->prepare(ps);
-    m_filter->setEnabled(true);
+    m_filter->setType(dsp::StateVariableTPTFilterType::lowpass);
+    m_filter->snapToZero();
 
     p_cutoff = m_parameters.getRawParameterValue(Consts::_FLTR_CUTOFF_PARAM_ID);
     p_resonance = m_parameters.getRawParameterValue(Consts::_FLTR_RESO_PARAM_ID);
@@ -47,7 +48,6 @@ void PhantomFilter::update() noexcept
     // function. Discontinuous numbers could result in artifacts.
 
     m_filter->setResonance(*p_resonance);
-    m_filter->setDrive(*p_drive);
 }
 
 //==============================================================================
@@ -59,12 +59,53 @@ float PhantomFilter::evaluate(float sample, float egMod, float lfoMod) noexcept
     float offset = k_cutoffModulationMultiplier * mod;
 
     float frequency = clip(*p_cutoff + offset, k_cutoffLowerBounds, k_cutoffUpperCounds);
-    m_filter->setCutoffFrequencyHz(frequency);
+    m_filter->setCutoffFrequency(frequency);
 
-    return m_filter->processSample(sample, k_channelNumber);
+    float distortion = htan(sample);
+    sample = (*p_drive * distortion) + ((1.0f - *p_drive) * sample);
+
+    return m_filter->processSample(k_channelNumber, sample);
 }
 
 float PhantomFilter::clip(float n, float lower, float upper) noexcept
 {
     return std::max(lower, std::min(n, upper));
+}
+
+//==============================================================================
+float PhantomFilter::htan(float x) noexcept
+{
+    return std::tanhf((*p_drive * 9.0f + 1.0f) * x);
+}
+
+float PhantomFilter::fexp2(float x) noexcept
+{
+    float s = sign(-x);
+    float t1 = 1.0f - std::expf(std::abs(x));
+    float t2 = MathConstants<float>::euler - 1.0f;
+
+    return s * t1 / t2;
+}
+
+float PhantomFilter::atsr(float x) noexcept
+{
+    float t1 = 2.5f * std::atan(0.9f * x);
+    float t2 = 2.5f * std::sqrtf(1.0f - std::powf(0.9f * x, 2.0f));
+
+    return t1 + t2 - 2.5f;
+}
+
+float PhantomFilter::cube(float x) noexcept
+{
+    return x * x * x;
+}
+
+float PhantomFilter::hclip(float x) noexcept
+{
+    return std::abs(x) > 0.5f ? 0.5f * sign(x) : x;
+}
+
+float PhantomFilter::sign(float x) noexcept
+{
+    return x >= 0.0f ? 1.0f : -1.0f;
 }

--- a/src/PhantomFilter.cpp
+++ b/src/PhantomFilter.cpp
@@ -16,13 +16,13 @@
 PhantomFilter::PhantomFilter(AudioProcessorValueTreeState& vts, dsp::ProcessSpec& ps)
     :   m_parameters(vts)
 {
-    m_filter = new dsp::StateVariableTPTFilter<float>();
+    m_filter = new dsp::LadderFilter<float>();
     m_filter->prepare(ps);
-    m_filter->setType(m_type);
-    m_filter->snapToZero();
+    m_filter->setEnabled(true);
 
     p_cutoff = m_parameters.getRawParameterValue(Consts::_FLTR_CUTOFF_PARAM_ID);
     p_resonance = m_parameters.getRawParameterValue(Consts::_FLTR_RESO_PARAM_ID);
+    p_drive = m_parameters.getRawParameterValue(Consts::_FLTR_DRIVE_PARAM_ID);
     p_egModDepth = m_parameters.getRawParameterValue(Consts::_FLTR_EG_MOD_DEPTH_PARAM_ID);
     p_lfoModDepth = m_parameters.getRawParameterValue(Consts::_FLTR_LFO_MOD_DEPTH_PARAM_ID);
 
@@ -35,6 +35,7 @@ PhantomFilter::~PhantomFilter()
 
     p_cutoff = nullptr;
     p_resonance = nullptr;
+    p_drive = nullptr;
     p_egModDepth = nullptr;
     p_lfoModDepth = nullptr;
 }
@@ -44,27 +45,23 @@ void PhantomFilter::update() noexcept
 {
     // NOTE: Frequency is not being set here because it is called in the update 
     // function. Discontinuous numbers could result in artifacts.
+
     m_filter->setResonance(*p_resonance);
+    m_filter->setDrive(*p_drive);
 }
 
 //==============================================================================
 float PhantomFilter::evaluate(float sample, float egMod, float lfoMod) noexcept
 {
-    // egMod = egMod * 2.0f - 1.0f;
-    // egMod *= *p_egModDepth;
-    // lfoMod *= *p_lfoModDepth;
-    // float mod = (egMod + lfoMod) * 0.5f + 0.5f;
-    // float offset = k_cutoffModulationMultiplier * mod;
-
     float envelope = *p_egModDepth * egMod * (abs(*p_lfoModDepth) * -0.5f + 1.0f);
     float lfo = *p_lfoModDepth * (lfoMod * 0.5f + 0.5f) * (abs(*p_egModDepth) * -0.5f + 1.0f);
     float mod = envelope + lfo;
     float offset = k_cutoffModulationMultiplier * mod;
 
     float frequency = clip(*p_cutoff + offset, k_cutoffLowerBounds, k_cutoffUpperCounds);
-    m_filter->setCutoffFrequency(frequency);
+    m_filter->setCutoffFrequencyHz(frequency);
 
-    return m_filter->processSample(k_channelNumber, sample);
+    return m_filter->processSample(sample, k_channelNumber);
 }
 
 float PhantomFilter::clip(float n, float lower, float upper) noexcept

--- a/src/PhantomFilter.h
+++ b/src/PhantomFilter.h
@@ -40,6 +40,7 @@ private:
 
     std::atomic<float>* p_cutoff;
     std::atomic<float>* p_resonance;
+    std::atomic<float>* p_drive;
     std::atomic<float>* p_egModDepth;
     std::atomic<float>* p_lfoModDepth;
 
@@ -49,6 +50,5 @@ private:
     const float k_cutoffUpperCounds = 11000.0f;
 
     //==========================================================================
-    dsp::StateVariableTPTFilter<float>* m_filter;
-    dsp::StateVariableTPTFilterType m_type = dsp::StateVariableTPTFilterType::lowpass;
+    dsp::LadderFilter<float>* m_filter;
 };

--- a/src/PhantomFilter.h
+++ b/src/PhantomFilter.h
@@ -36,6 +36,19 @@ private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PhantomFilter)
 
     //==========================================================================
+    // NOTE: These functions are non-linear processing functions to give the 
+    // filter a nice drive feature. They are in order of increasing intensity.
+    // The function with an asterisk in the comment is currently being used.
+
+    float fexp2(float x) noexcept;      // Fuzz Exponential 2
+    float atsr(float x) noexcept;       // Arctangent Square Root
+    float cube(float x) noexcept;       // Cube
+    float htan(float x) noexcept;       // Hyperbolic Tangent*
+    float hclip(float x) noexcept;      // Hard Clip
+
+    float sign(float x) noexcept;
+
+    //==========================================================================
     AudioProcessorValueTreeState& m_parameters;
 
     std::atomic<float>* p_cutoff;
@@ -44,11 +57,13 @@ private:
     std::atomic<float>* p_egModDepth;
     std::atomic<float>* p_lfoModDepth;
 
+    float m_previousFrequency;
+
     const int k_channelNumber = 0;
     const float k_cutoffModulationMultiplier = 3000.0f;
     const float k_cutoffLowerBounds = 0.0f;
     const float k_cutoffUpperCounds = 11000.0f;
 
     //==========================================================================
-    dsp::LadderFilter<float>* m_filter;
+    dsp::StateVariableTPTFilter<float>* m_filter;
 };

--- a/src/PhantomProcessor.cpp
+++ b/src/PhantomProcessor.cpp
@@ -250,6 +250,13 @@ AudioProcessorValueTreeState::ParameterLayout PhantomAudioProcessor::createParam
     );
     params.push_back(std::move(filterReso));
 
+    auto filterDrive = std::make_unique<AudioParameterFloat>(
+        Consts::_FLTR_DRIVE_PARAM_ID, Consts::_FLTR_DRIVE_PARAM_NAME,
+        NormalisableRange<float>(1.0f, 10.0f, 0.1f),
+        Consts::_FLTR_DRIVE_DEFAULT_VAL
+    );
+    params.push_back(std::move(filterDrive));
+
     auto filterEgModDepth = std::make_unique<AudioParameterFloat>(
         Consts::_FLTR_EG_MOD_DEPTH_PARAM_ID, Consts::_FLTR_EG_MOD_DEPTH_PARAM_NAME,
         NormalisableRange<float>(-1.0f, 1.0f, 0.01f),

--- a/src/PhantomProcessor.cpp
+++ b/src/PhantomProcessor.cpp
@@ -252,7 +252,7 @@ AudioProcessorValueTreeState::ParameterLayout PhantomAudioProcessor::createParam
 
     auto filterDrive = std::make_unique<AudioParameterFloat>(
         Consts::_FLTR_DRIVE_PARAM_ID, Consts::_FLTR_DRIVE_PARAM_NAME,
-        NormalisableRange<float>(1.0f, 10.0f, 0.1f),
+        NormalisableRange<float>(0.0f, 1.0f, 0.01f),
         Consts::_FLTR_DRIVE_DEFAULT_VAL
     );
     params.push_back(std::move(filterDrive));

--- a/src/PhantomUtils.h
+++ b/src/PhantomUtils.h
@@ -109,6 +109,9 @@ namespace Consts {
     constexpr char* _FLTR_RESO_PARAM_ID = "filterReso";
     constexpr char* _FLTR_RESO_PARAM_NAME = "Filter Resonance";
     constexpr float _FLTR_RESO_DEFAULT_VAL = 0.70710678;
+    constexpr char* _FLTR_DRIVE_PARAM_ID = "filterDrive";
+    constexpr char* _FLTR_DRIVE_PARAM_NAME = "Filter Drive";
+    constexpr float _FLTR_DRIVE_DEFAULT_VAL = 1.0f;
     constexpr char* _FLTR_EG_MOD_DEPTH_PARAM_ID = "filterEgModDepth";
     constexpr char* _FLTR_EG_MOD_DEPTH_PARAM_NAME = "Filter EG Mod Depth";
     constexpr float _FLTR_EG_MOD_DEPTH_DEFAULT_VAL = 0.0f;

--- a/src/PhantomUtils.h
+++ b/src/PhantomUtils.h
@@ -111,7 +111,7 @@ namespace Consts {
     constexpr float _FLTR_RESO_DEFAULT_VAL = 0.70710678;
     constexpr char* _FLTR_DRIVE_PARAM_ID = "filterDrive";
     constexpr char* _FLTR_DRIVE_PARAM_NAME = "Filter Drive";
-    constexpr float _FLTR_DRIVE_DEFAULT_VAL = 1.0f;
+    constexpr float _FLTR_DRIVE_DEFAULT_VAL = 0.0f;
     constexpr char* _FLTR_EG_MOD_DEPTH_PARAM_ID = "filterEgModDepth";
     constexpr char* _FLTR_EG_MOD_DEPTH_PARAM_NAME = "Filter EG Mod Depth";
     constexpr float _FLTR_EG_MOD_DEPTH_DEFAULT_VAL = 0.0f;


### PR DESCRIPTION
## Type

- [ ] _chore_ - simple, grunt tasks like updating a library
- [x] _feature_ - implementation of a new functionality, behavior, design, etc.
- [ ] _fix_ - fixing bugs or other things
- [ ] _refactor_ - improving existing code without changing external behavior
- [ ] _sandbox_ - prototyping, designing, or testing new things
- [ ] _test_ - things related to tests

## Summary

I originally wanted to use JUCE's LadderFilter as my main filter choice, but it doesn't like to be modulated too quickly (the SmoothedValue types make the CPU usage spike like mad). For that reason, I am going to stick with the "normal" StateVariableFilter and just implement my version of a filter drive.

*NOTE: The planned implementation for this card will **NOT** contain parameters to control the slope or mode (HP, LP, BP, etc.). This will be added later in a more finalized GUI state since these (IMO) aren't the most important filter parameters to worry about.*

[Trello Card](https://trello.com/c/pYDFgiTF/30-02-01-2021-feature-filter-drive)

## Notes

- The StateVariableFilter's implementation is quick and easy, so modulating the frequency at audio-rate is perfectly fine (internal function is simply setting three variables...)
- I implemented my own drive functionality using a common `tanh(sample * gain)` algorithm so I could still have that distorted goodness without stressing the CPU